### PR TITLE
Write uiLayoutCtrl as a constructor

### DIFF
--- a/src/ui-layout.js
+++ b/src/ui-layout.js
@@ -7,10 +7,8 @@
 angular.module('ui.layout', [])
   .controller('uiLayoutCtrl', ['$scope', '$attrs', '$element', function uiLayoutCtrl($scope, $attrs, $element) {
     // Gives to the children directives the access to the parent layout.
-    return {
-      opts: angular.extend({}, $scope.$eval($attrs.uiLayout), $scope.$eval($attrs.options)),
-      element: $element
-    };
+    this.opts = angular.extend({}, $scope.$eval($attrs.uiLayout), $scope.$eval($attrs.options));
+    this.element = $element;
   }])
 
   .directive('uiLayout', ['$parse', function ($parse) {


### PR DESCRIPTION
In Angular 1.3.0 final the controller is used as a constructor. The returned value is ignored, and angular-ui-layout does not work.
