### PR TITLE
Fixed minification for directive parameters

### DIFF
--- a/src/ui-layout.js
+++ b/src/ui-layout.js
@@ -420,7 +420,7 @@ angular.module('ui.layout', [])
     return ctrl;
   }])
 
-  .directive('uiLayout', function($window) {
+  .directive('uiLayout', ['$window', function($window) {
     return {
       restrict: 'AE',
       controller: 'uiLayoutCtrl',
@@ -442,9 +442,9 @@ angular.module('ui.layout', [])
         });
       }
     };
-  })
+  }])
 
-  .directive('uiSplitbar', function(LayoutContainer) {
+  .directive('uiSplitbar', ['LayoutContainer', function(LayoutContainer) {
     // Get all the page.
     var htmlElement = angular.element(document.body.parentElement);
 
@@ -624,9 +624,9 @@ angular.module('ui.layout', [])
       }
     };
 
-  })
+  }])
 
-  .directive('uiLayoutContainer', function(LayoutContainer) {
+  .directive('uiLayoutContainer', ['LayoutContainer', function(LayoutContainer) {
     return {
       restrict: 'AE',
       require: '^uiLayout',
@@ -659,7 +659,7 @@ angular.module('ui.layout', [])
         };
       }
     };
-  })
+  }])
 
   .factory('LayoutContainer', function() {
 


### PR DESCRIPTION
The uiLayout, uiSplitbar and uiLayoutContainer directives were not
using named parameters, so minification/uglification caused ui-layout
to no longer work.
