### PR TITLE
Fix misaligned chevron

### DIFF
--- a/src/ui-layout.css
+++ b/src/ui-layout.css
@@ -39,6 +39,9 @@
   cursor: col-resize;
   -webkit-flex-direction: column;
   flex-direction: column;
+  text-align: center;
+  justify-content: center;
+  align-items: center;
 }
 
 .ui-layout-column > .ui-splitbar > a,


### PR DESCRIPTION
If in Holy Grail demo you add `dividerSize:30` for

```html
<div ui-layout="{flow : 'column', dividerSize:30}">
```

you will see the chevrons are aligned to the left,
not centered.

This commit centers those chevrons.