### PR TITLE
Fix extraneous scrollbar

### DIFF
--- a/src/ui-layout.css
+++ b/src/ui-layout.css
@@ -33,12 +33,14 @@
   text-align: center;
   justify-content: center;
   align-items: center;
+  overflow-y: hidden;
 }
 .ui-layout-column > .ui-splitbar{
   width: 8px; height: 100%;
   cursor: col-resize;
   -webkit-flex-direction: column;
   flex-direction: column;
+  overflow-x: hidden;
 }
 
 .ui-layout-column > .ui-splitbar > a,


### PR DESCRIPTION
In *Chrome 39.0.2171.65 (64-bit)* and *Chrome 41.0.2272.89 m*
sometimes in splitbars there is an artifact, which is a scrollbar
squished beyond recognition, which shouldn't be there.

More often seen if adding CSS

```css
.ui-splitbar { border: thin solid grey; }
```

This commit removes that scrollbar by overflow.