### PR TITLE
Keep resize cursor better while dragging

### DIFF
--- a/src/ui-layout.js
+++ b/src/ui-layout.js
@@ -123,7 +123,7 @@ angular.module('ui.layout', [])
         (mouseEvent.originalEvent && mouseEvent.originalEvent[ctrl.sizeProperties.mouseProperty]) ||
         (mouseEvent.targetTouches ? mouseEvent.targetTouches[0][ctrl.sizeProperties.mouseProperty] : 0);
 
-      lastPos = mousePos - offset($element)[ctrl.sizeProperties.offsetPos];
+      lastPos = mousePos - opts.dividerSize / 2 - offset($element)[ctrl.sizeProperties.offsetPos];
 
       //Cancel previous rAF call
       if(animationFrameRequested) {


### PR DESCRIPTION
Hitherto when carefully dragging column splitbar to the left or row splitbar
to the top then cursor exiting splitbar proper changed from resize to other.

That was visually annoying, flickering.

This fix makes the cursor remain resize much better.

By saying "mouse is in middle of splitbar" it stays within splitbar better.

Have verified it still correctly respects `min-size`.