### PR TITLE
chore(commonjs): Added support for npm commonjs

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,3 @@
+require('./src/ui-layout.css');
 require('./src/ui-layout.js');
 module.exports = 'ui.layout';
-

--- a/index.js
+++ b/index.js
@@ -1,0 +1,3 @@
+require('./src/ui-layout.js');
+module.exports = 'ui.layout';
+

--- a/index.js
+++ b/index.js
@@ -1,3 +1,3 @@
-require('./src/ui-layout.css');
-require('./src/ui-layout.js');
+require('./src/ui-layout');
 module.exports = 'ui.layout';
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-ui-layout",
-  "version": "1.0.5",
+  "version": "1.0.5-requirejs",
   "description": "This directive allows you to split !",
   "devDependencies": {
     "angular-ui-publisher": "~1.2",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "lodash.assign": "^2",
     "node-karma-wrapper": "^0"
   },
-  "main": "src/ui-layout.js",
+  "main": "index.js",
   "repository": {
     "type": "git",
     "url": "git://github.com/angular-ui/ui-layout.git"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "lodash.assign": "^2",
     "node-karma-wrapper": "^0"
   },
-  "main": "ui-layout.js",
+  "main": "src/ui-layout.js",
   "repository": {
     "type": "git",
     "url": "git://github.com/angular-ui/ui-layout.git"


### PR DESCRIPTION
Added `ui.layout` to module exports so that after installing via npm, the package can be required in the angular module dependency list such as:

```angular.module('myApp', [require('angular-ui-layout')]);```

This is helpful for Browserify and Webpack.