### PR TITLE
Added support for npm commonjs

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,3 @@
+require('.src/ui-layout');
+module.exports = 'ui.layout';
+

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "lodash.assign": "^2",
     "node-karma-wrapper": "^0"
   },
-  "main": "ui-layout.js",
+  "main": "index.js",
   "repository": {
     "type": "git",
     "url": "git://github.com/angular-ui/ui-layout.git"


### PR DESCRIPTION
Added `ui.layout` to module exports so that after installing via npm, the package can be required in the angular module dependency list such as:

```angular.module('myApp', [require('angular-ui-layout')]);```

This is helpful for Browserify and Webpack.