### PR TITLE
Fix digest in progress issue with when resizing

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "gulp-uglify": "^0",
     "gulp-util": "^2",
     "jshint-stylish": "^0",
-    "karma": "^0",
+    "karma": "^0.12",
     "karma-chrome-launcher": "^0",
     "karma-coverage": "^0",
     "karma-firefox-launcher": "^0",

--- a/src/ui-layout.js
+++ b/src/ui-layout.js
@@ -433,7 +433,7 @@ angular.module('ui.layout', [])
     return ctrl;
   }])
 
-  .directive('uiLayout', ['$window', function($window) {
+  .directive('uiLayout', ['$window','$timeout' function($window,$timeout) {
     return {
       restrict: 'AE',
       controller: 'uiLayoutCtrl',
@@ -443,7 +443,7 @@ angular.module('ui.layout', [])
         });
 
         function onResize() {
-          scope.$apply(function() {
+          $timeout(function() { 
             ctrl.updateDisplay();
           });
         }

--- a/src/ui-layout.js
+++ b/src/ui-layout.js
@@ -433,7 +433,7 @@ angular.module('ui.layout', [])
     return ctrl;
   }])
 
-  .directive('uiLayout', ['$window','$timeout' function($window,$timeout) {
+  .directive('uiLayout', ['$window','$timeout', function($window,$timeout) {
     return {
       restrict: 'AE',
       controller: 'uiLayoutCtrl',


### PR DESCRIPTION
Updated `scope.$apply` to use `$timeout` as `$apply` can throw exception when performed whilst another digest is in progress. See [SO answer](http://stackoverflow.com/a/18996042/670151) and linked Angular repo is regard to waiting for a digest to complete.

Hit this problem with a parent element of `ui-layout` directive was resizing early on when loading the page, was consistent though.