### PR TITLE
Add print rules

### DIFF
--- a/src/ui-layout.css
+++ b/src/ui-layout.css
@@ -47,3 +47,18 @@
   cursor: pointer;
   font-size: 9px;
 }
+
+@media print {
+  .ui-splitbar {
+    display: none;
+  }
+
+  .stretch {
+    position: relative;
+  }
+  /* The last item can take up any amount of space. */
+  .stretch.ui-layout-container:last-child {
+    position: static;
+    overflow: visible;
+  }
+}


### PR DESCRIPTION
Resolves #94. I've only tested this with the layout I use: two horizontal panes split at 50%, covering the whole page. It works well in that case, but I'm not a CSS expert. I guess it's better than having no print rules. If someone finds that this does not cover their layout well, they can always improve it further.