### PR TITLE
fix #139 delete container don't make splitbar sticky

### DIFF
--- a/src/ui-layout.js
+++ b/src/ui-layout.js
@@ -758,7 +758,7 @@ angular.module('ui.layout', [])
         });
 
         scope.$on('$destroy', function() {
-          htmlElement.off('mouseup touchend mousemove touchmove');
+          htmlElement.off('mousemove touchmove');
         });
 
         //Add splitbar to layout container list


### PR DESCRIPTION
When container where deleted, the splitbar stick to the cursor even after
releasing the mouse press.