### PR TITLE
feat: Enable hiding splitbar

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ A fake [flex-direction property](http://www.w3.org/TR/css3-flexbox/#flex-directi
 Type: `Integer`
 Default: `10`
 
-The size in pixels that you want the divider/splitbar to be.
+The size in pixels that you want the divider/splitbar to be. Set to `0` to hide the splitbar, which in turn prevents user resizing the surrounding containers.
 
 ### disableToggle
 

--- a/src/ui-layout.js
+++ b/src/ui-layout.js
@@ -41,7 +41,7 @@ angular.module('ui.layout', [])
     opts.sizes = opts.sizes || [];
     opts.maxSizes = opts.maxSizes || [];
     opts.minSizes = opts.minSizes || [];
-    opts.dividerSize = opts.dividerSize || 10; //default divider size set to 10
+    opts.dividerSize = opts.dividerSize === undefined ? 10 : opts.dividerSize;
     opts.collapsed = opts.collapsed || [];
     ctrl.opts = opts;
 


### PR DESCRIPTION
Setting @dividerSize=0 will hide this splitbar and prevent from resizing
the surrounding container.

This is a desirable feature to allow containers managed by the layout, while
hiding the splitbar.