### PR TITLE
Add class "ui-layout-hidden" for hidden containers

### DIFF
--- a/src/ui-layout.css
+++ b/src/ui-layout.css
@@ -152,3 +152,8 @@
     overflow: visible;
   }
 }
+
+/* Make sure hidden elements are in fact not rendered. */
+.ui-layout-hidden {
+  display: none;
+}

--- a/src/ui-layout.js
+++ b/src/ui-layout.js
@@ -928,6 +928,11 @@ angular.module('ui.layout', [])
 
                 scope.$watch('container.size', function(newValue) {
                   element.css(ctrl.sizeProperties.sizeProperty, newValue + 'px');
+                  if(newValue === 0) {
+                    element.addClass('ui-layout-hidden');
+                  } else {
+                    element.removeClass('ui-layout-hidden');
+                  }
                 });
 
                 scope.$watch('container.' + ctrl.sizeProperties.flowProperty, function(newValue) {


### PR DESCRIPTION
This PR adds a `ui-layout-hidden` class to hidden containers elements.

The motivation for this PR is that, if a container has content with `absolute` positioning and non-zero `padding`, the contents of the containers overlap if either of them gets collapsed. (tested under Chrome 46.0)

The `ui-layout-hidden` class allows us to handle hidden containers via CSS, e.g., using `display: none`.

I've created a simple plunkr here. You can try to uncomment either of the two `<script ..>` imports to see the difference:
http://plnkr.co/edit/mNYI8S6FBReKm5hOC9sj?p=preview