### PR TITLE
Remove all size options along with the container.

### DIFF
--- a/src/ui-layout.js
+++ b/src/ui-layout.js
@@ -395,6 +395,9 @@ angular.module('ui.layout', [])
         var newIndex = ctrl.containers.indexOf(container);
         if(newIndex >= 0) {
           ctrl.containers.splice(newIndex, 1);
+          ctrl.opts.maxSizes.splice(newIndex, 1);
+          ctrl.opts.minSizes.splice(newIndex, 1);
+          ctrl.opts.sizes.splice(newIndex, 1);
         }
         ctrl.calculate();
       } else {


### PR DESCRIPTION
An attempt to fix #150.

I assumed the number of elements in ```ctrl.containers``` directly matches the number of elements within the size option arrays.