### PR TITLE
Handle

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,13 @@ Default: `false`
 
 Like `disableToggle` above but only removes the arrows on mobile devices (max-device-width: 480px).
 
+### showHandle
+
+Type: `Boolean`
+Default: `false`
+
+Whether to show a handle in the middle of a splitbar. If toggle is enabled at the same time, the handle is shown between
+the two toggle buttons. The handle has the css class `.ui-splitbar-handle`.
 
 ## Child Attributes
 

--- a/src/ui-layout.css
+++ b/src/ui-layout.css
@@ -131,7 +131,7 @@
   width: 10px;
   height: 2px;
   box-shadow: inset 0 0 0 32px, 0 -6px, 0 6px;
-  margin: 0;
+  margin: 12px 0;
 }
 
 /* Allow disabling of icons */

--- a/src/ui-layout.css
+++ b/src/ui-layout.css
@@ -128,7 +128,7 @@
 }
 
 /* Allow disabling of icons */
-.no-toggle .ui-splitbar-icon {
+.no-toggle .ui-splitbar-toggle {
   display: none;
 }
 

--- a/src/ui-layout.css
+++ b/src/ui-layout.css
@@ -127,6 +127,13 @@
   margin-top: 0.45em;
 }
 
+.ui-splitbar-handle {
+  width: 10px;
+  height: 2px;
+  box-shadow: inset 0 0 0 32px, 0 -6px, 0 6px;
+  margin: 0;
+}
+
 /* Allow disabling of icons */
 .no-toggle .ui-splitbar-toggle {
   display: none;

--- a/src/ui-layout.css
+++ b/src/ui-layout.css
@@ -132,6 +132,10 @@
   display: none;
 }
 
+.no-handle .ui-splitbar-handle {
+  display: none;
+}
+
 @media only screen and (max-device-width: 480px) {
   .no-mobile-toggle .ui-splitbar-icon {
     display: none;

--- a/src/ui-layout.js
+++ b/src/ui-layout.js
@@ -52,6 +52,9 @@ angular.module('ui.layout', [])
     if (opts.disableMobileToggle) {
       $element.addClass('no-mobile-toggle');
     }
+    if (!opts.showHandle) {
+      $element.addClass('no-handle');
+    }
 
     // Initial global size definition
     opts.sizes = opts.sizes || [];

--- a/src/ui-layout.js
+++ b/src/ui-layout.js
@@ -688,7 +688,7 @@ angular.module('ui.layout', [])
 
         //icon <a> elements
         var prevButton = angular.element(element.children()[0]);
-        var afterButton = angular.element(element.children()[1]);
+        var afterButton = angular.element(element.children()[2]);
 
         //icon <span> elements
         var prevIcon = angular.element(prevButton.children()[0]);
@@ -947,8 +947,9 @@ angular.module('ui.layout', [])
                 var children = parent.children();
                 var index = ctrl.indexOfElement(element);
                 var splitbar = angular.element('<div ui-splitbar>' +
-                  '<a><span class="ui-splitbar-icon"></span></a>' +
-                  '<a><span class="ui-splitbar-icon"></span></a>' +
+                  '<a><span class="ui-splitbar-icon ui-splitbar-toggle"></span></a>' +
+                  '<a><span class="ui-splitbar-icon ui-splitbar-handle ui-splitbar-icon-up"></span></a>' +
+                  '<a><span class="ui-splitbar-icon ui-splitbar-toggle"></span></a>' +
                   '</div>');
                 if(0 < index && !ctrl.hasSplitbarBefore(scope.container)) {
                   angular.element(children[index-1]).after(splitbar);

--- a/src/ui-layout.js
+++ b/src/ui-layout.js
@@ -425,7 +425,7 @@ angular.module('ui.layout', [])
         el = splitter.element[0].children[0];
       } else {
         splitter = ctrl.containers[index - 1];
-        el = splitter.element[0].children[1];
+        el = splitter.element[0].children[2];
       }
 
       $timeout(function(){
@@ -717,7 +717,7 @@ angular.module('ui.layout', [])
 
           if(previousSplitbar !== null) {
             prevSplitbarBeforeButton = angular.element(previousSplitbar.element.children()[0]);
-            prevSplitbarAfterButton = angular.element(previousSplitbar.element.children()[1]);
+            prevSplitbarAfterButton = angular.element(previousSplitbar.element.children()[2]);
           }
 
           if(ctrl.isUsingColumnFlow) {
@@ -777,7 +777,7 @@ angular.module('ui.layout', [])
 
           if(nextSplitbar !== null) {
             nextSplitbarBeforeButton = angular.element(nextSplitbar.element.children()[0]);
-            nextSplitbarAfterButton = angular.element(nextSplitbar.element.children()[1]);
+            nextSplitbarAfterButton = angular.element(nextSplitbar.element.children()[2]);
           }
 
           if(ctrl.isUsingColumnFlow) {

--- a/src/ui-layout.js
+++ b/src/ui-layout.js
@@ -951,7 +951,7 @@ angular.module('ui.layout', [])
                 var index = ctrl.indexOfElement(element);
                 var splitbar = angular.element('<div ui-splitbar>' +
                   '<a><span class="ui-splitbar-icon ui-splitbar-toggle"></span></a>' +
-                  '<a><span class="ui-splitbar-icon ui-splitbar-handle ui-splitbar-icon-up"></span></a>' +
+                  '<a><span class="ui-splitbar-icon ui-splitbar-handle"></span></a>' +
                   '<a><span class="ui-splitbar-icon ui-splitbar-toggle"></span></a>' +
                   '</div>');
                 if(0 < index && !ctrl.hasSplitbarBefore(scope.container)) {

--- a/test/layout-scenar.spec.js
+++ b/test/layout-scenar.spec.js
@@ -141,7 +141,7 @@ function splitMoveTests(description, startEvent, moveEvent, endEvent) {
 
         beforeEach(function() {
           toggleBeforeButton = $splitbar.children()[0];
-          toggleAfterButton = $splitbar.children()[1];
+          toggleAfterButton = $splitbar.children()[2];
         });
 
         it('should exist', function() {


### PR DESCRIPTION
This PR adds the possibility to add a handle icon to the middle of a splitbar. The handle will not trigger a collapse and will be visible even if `disableToggle` is set to true. By default, the handle is not visible and it needs to be explicitly enabled by setting the option `showHandle` to true.