### PR TITLE
Respect min-size when collapsing

### DIFF
--- a/src/ui-layout.js
+++ b/src/ui-layout.js
@@ -265,7 +265,7 @@ angular.module('ui.layout', [])
           if(!LayoutContainer.isSplitbar(ctrl.containers[i])) {
 
             c = ctrl.containers[i];
-            opts.sizes[i] = c.isCentral ? 'auto' : c.collapsed ? '0px' : optionValue(c.uncollapsedSize) || 'auto';
+            opts.sizes[i] = c.isCentral ? 'auto' : c.collapsed ? (optionValue(c.minSize) || '0px') : optionValue(c.uncollapsedSize) || 'auto';
             opts.minSizes[i] = optionValue(c.minSize);
             opts.maxSizes[i] = optionValue(c.maxSize);
 


### PR DESCRIPTION
Current behavior:

When collapsing a container, the size of the container is set to 0px.

![collapse](https://cloud.githubusercontent.com/assets/318295/12464752/2e261f82-bf90-11e5-8f53-95ac65d1b8c5.gif)

Proposed behavior:

When collapsing a container, the size of the container equals the min-size. If no min size is set, the container collapses to 0px.

![collapse-min](https://cloud.githubusercontent.com/assets/318295/12464771/4855f8dc-bf90-11e5-9df8-c4cea76d8cc6.gif)