### PR TITLE
toggle button for right of bottom container does not work

### DIFF
--- a/src/ui-layout.js
+++ b/src/ui-layout.js
@@ -525,7 +525,7 @@ angular.module('ui.layout', [])
           if(prevContainer) {
             prevContainer.size += (c.uncollapsedSize + endDiff);
           }
-
+          prevContainer.uncollapsedSize = null;
         } else {
           c.size = c.uncollapsedSize;
 


### PR DESCRIPTION
toggle button for right of bottom container does not work or is broken after small resize, see issue #209

fix brought from stackoverflow answer http://stackoverflow.com/questions/34310279/angular-ui-layout-toggle-not-working