### PR TITLE
fix layout memory leak

### DIFF
--- a/src/ui-layout.js
+++ b/src/ui-layout.js
@@ -17,7 +17,7 @@ angular.module('ui.layout', [])
     // regex to verify size is properly set to pixels or percent
     var sizePattern = /\d+\s*(px|%)\s*$/i;
 
-    Layout.addLayout(ctrl);
+    var unsubscribeLayout = Layout.addLayout(ctrl);
 
     ctrl.containers = [];
     ctrl.movingSplitbar = null;
@@ -638,6 +638,10 @@ angular.module('ui.layout', [])
       return -1;
     };
 
+    ctrl.destroy = function() {
+      unsubscribeLayout();
+    };
+
     return ctrl;
   }])
 
@@ -662,6 +666,7 @@ angular.module('ui.layout', [])
 
         scope.$on('$destroy', function() {
           angular.element($window).unbind('resize', onResize);
+          ctrl.destroy();
         });
       }
     };
@@ -1002,7 +1007,8 @@ angular.module('ui.layout', [])
     var layouts = [],
       collapsing = [],
       toBeCollapsed = 0,
-      toggledDeffered =  null;
+      toggledDeffered =  null,
+      layoutId = 0;
 
     function toggleContainer(container) {
       try {
@@ -1015,8 +1021,12 @@ angular.module('ui.layout', [])
 
     return {
       addLayout: function (ctrl) {
-        ctrl.id = layouts.length;
+        ctrl.id = layoutId++;
         layouts.push(ctrl);
+
+        return function() {
+          layouts.splice(layouts.indexOf(ctrl), 1);
+        }
       },
       addCollapsed: function(container) {
         collapsing.push(container);

--- a/test/uiLayoutCtrl.spec.js
+++ b/test/uiLayoutCtrl.spec.js
@@ -2,14 +2,16 @@
 
 
 describe('Controller: uiLayoutCtrl', function () {
-  var scope, $controller;
+  var scope, $controller, Layout;
+
   beforeEach(function () {
 
     module('ui.layout');
 
-    inject(function ($rootScope, _$controller_) {
+    inject(function ($rootScope, _$controller_, _Layout_) {
       scope = $rootScope.$new();
       $controller = _$controller_;
+      Layout = _Layout_;
     });
   });
 
@@ -35,6 +37,28 @@ describe('Controller: uiLayoutCtrl', function () {
       expect(uic.isLayoutElement(attrSplitbar)).toEqual(true);
       expect(uic.isLayoutElement(tagContainer)).toEqual(true);
       expect(uic.isLayoutElement(notUiEl)).toEqual(false);
+    });
+
+    it('destroy should call the unsubscribe function returned by Layout.addLayout', function () {
+      var unsubscribeLayout = jasmine.createSpy('unsubscribeLayout');
+
+      spyOn(Layout, 'addLayout');
+      Layout.addLayout.and.callFake(function(){
+        return unsubscribeLayout;
+      });
+
+      var uic = $controller('uiLayoutCtrl', {
+        $scope: scope,
+        $attrs: {},
+        $element: angular.element('<div></div>')
+      });
+
+      expect(Layout.addLayout).toHaveBeenCalledWith(uic);
+      expect(unsubscribeLayout).not.toHaveBeenCalled();
+
+      uic.destroy();
+
+      expect(unsubscribeLayout).toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
I fixed a memory leak in Layout service addLayout method by removing the controller from the layouts array when the directive ui-layout is destroyed.

I also changed the layout id generation from the array length (because we remove items when layout directive destroyed) to a simple increment.