### PR TITLE
README.md collapsed example fix & bower install

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,13 +29,11 @@ angular.module('myApp', [require('angular-ui-layout')]);
 ### [Bower](http://bower.io/)
 
 ```sh
-bower install angular-ui-layout\#bower
+bower install angular-ui-layout
 # or
 bower install angular-ui-layout\#v0.0.0
 # or
 bower install angular-ui-layout\#src0.0.0
-# or
-bower install angular-ui-layout
 ```
 
 This will copy the UI.Layout files into a `bower_components` folder, along with its dependencies. Load the script files in your application:

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ bower install angular-ui-layout\#bower
 bower install angular-ui-layout\#v0.0.0
 # or
 bower install angular-ui-layout\#src0.0.0
+# or
+bower install angular-ui-layout
 ```
 
 This will copy the UI.Layout files into a `bower_components` folder, along with its dependencies. Load the script files in your application:
@@ -130,7 +132,7 @@ The `'central'` container takes up all the remaining space during resizing, rega
 Type: `boolean`
 
 ```xml
-<div ui-layout>
+<div ui-layout ui-layout-loaded>
     <div ui-layout-container collapsed="true"></div>    
     <div ui-layout-container collapsed="layout.mycontainer"></div>    
 </div>


### PR DESCRIPTION
Collapsed doesn't work without ui-layout-loaded attribute.
Also updated bower install instructions based on https://github.com/angular-ui/ui-layout/issues/183